### PR TITLE
Add code quality linting checks via `ruff` through `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,10 @@ repos:
       - id: bandit
         args: ["-c", "pyproject.toml"]
         additional_dependencies: ["bandit[toml]"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.4.9"
+    hooks:
+      - id: ruff
   - repo: https://github.com/rhysd/actionlint
     rev: v1.6.27
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ files = ["src/almanack/__init__.py"]
 # set persistent versions within the __init__.py file in cases
 # where we may not have or want access to full git history
 [tool.poetry-dynamic-versioning.files."src/almanack/__init__.py"]
-persistent-substitution = true
+persistent-substitution = false
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,26 @@ ignore-words="styles/config/vocabularies/almanack/accept.txt"
 # referenced from: https://github.com/codespell-project/codespell/issues/1212
 ignore-regex=".{1024}|.*codespell-ignore.*"
 
+[tool.ruff]
+target-version = "py311"
+fix = true
+
+[tool.ruff.lint]
+select = [
+    # pyflakes
+    "F",
+    # pylint
+    "PL",
+    # mccabe
+    "C90",
+    # ruff
+    "RUF",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Ignore `E402` and `F401` (unused imports) in all `__init__.py` files
+"__init__.py" = ["F401"]
+
 # defines poe the poet tasks
 [tool.poe.tasks]
 # builds the jupyter book related to this project

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,7 @@ def build_jupyter_book(
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        check=False,
     )
 
     check_subproc_run_for_nonzero(completed_proc=result)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -23,7 +23,7 @@ def test_links(build_jupyter_book: pathlib.Path) -> None:
             "linkchecker",
             f"{build_jupyter_book}/",
             "--ignore-url",
-            f"html/_static",
+            "html/_static",
             # used to check external-facing links
             "--check-extern",
             # used to avoid warnings triggering a non-zero return
@@ -33,6 +33,7 @@ def test_links(build_jupyter_book: pathlib.Path) -> None:
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        check=False,
     )
 
     check_subproc_run_for_nonzero(completed_proc=result)
@@ -59,5 +60,6 @@ def test_web_accessibility(build_jupyter_book: pathlib.Path) -> None:
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                check=False,
             )
         )


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR adds a few code quality linting checks via [`ruff`](https://docs.astral.sh/ruff/) to help us develop the `almanack` Python package and related. These checks are performed through the existing `pre-commit` workflows related to the repository. They're also meant to perform checks gradually, meaning new code is checked but we haven't retroactively changed any other code to meet these standards. That said, some minor changes to existing code are applied to help pass the initial settings.

Through these changes we will use [`pyflakes`](https://docs.astral.sh/ruff/rules/#pyflakes-f), [`pylint`](https://docs.astral.sh/ruff/rules/#pylint-pl), [`mccabe`](https://docs.astral.sh/ruff/rules/#mccabe-c90), and [`ruff`-specific rules](https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf) to check code.

Thanks for any feedback you may have!

Closes #56 

## What is the nature of your change?

- [ ] Content additions or updates (adds or updates content)
- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own contributions.
- [x] I have commented my content, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to related documentation (outside of book content).
- [x] My changes generate no new warnings.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests that prove my additions are effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
