### PR TITLE
Avoid PDF-specific single-page formatting for GitHub Pages builds

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -25,8 +25,8 @@ jobs:
           poetry run poe build-book-pdf
       - name: Copy and rename the PDF to the HTML dir
         run: |
-          cp src/book/_build/pdf/book.pdf \
-          src/book/_build/html/software-gardening-almanack.pdf
+          cp src/_pdfbuild/_build/pdf/book.pdf \
+          src/_build/html/software-gardening-almanack.pdf
       - name: Add nojekyll config for GH pages
         run: |
           touch src/book/_build/html/.nojekyll

--- a/.gitignore
+++ b/.gitignore
@@ -300,3 +300,6 @@ dist
 
 # for ignoring vale package installs
 /styles
+
+# ignore pdf builds
+/src/_pdfbuild

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,8 @@ build-book.shell = """
 """
 # build a PDF from the HTML content
 build-book-pdf.shell = """
-  jupyter-book build src/book --builder pdfhtml
+  cp -r src/book src/_pdfbuild &&
+  jupyter-book build src/_pdfbuild --builder pdfhtml
 """
 # builds the jupyter book related to this project and opens a new browser window
 build-book-dev.shell = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,8 @@ build-book.shell = """
   jupyter-book build src/book --all
 """
 # build a PDF from the HTML content
+# note: depends on build-book content and creates copy to avoid
+# single-page changes performed on the HTML build.
 build-book-pdf.shell = """
   cp -r src/book src/_pdfbuild &&
   jupyter-book build src/_pdfbuild --builder pdfhtml


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

The PDF build of the book content depends on the HTML build. When creating the PDF, the HTML build is modified to entail a "single-page" build which modifies the way navigation works and adds all book content to a single HTML webpage. I noticed this was happening with GitHub Pages builds of the book's content (it's manually fixed in the latest version on `gh-pages`). This PR keeps these build procedures distinct by creating a copy of the HTML build before building the PDF (which is done separately to avoid the single page changes mentioned).

Thanks for any thoughts or feedback you may have!

Closes #74 

## What is the nature of your change?

- [ ] Content additions or updates (adds or updates content)
- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own contributions.
- [x] I have commented my content, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to related documentation (outside of book content).
- [x] My changes generate no new warnings.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests that prove my additions are effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
