### PR TITLE
Disable notebook execution for book content

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,10 @@ if [ $(echo "$output" | wc -l) -gt 1 ]; then
 echo "$output"; exit 1;
 fi
 """
+# add a convenience task for package-focused testing
+pkg-tests.shell = """
+pytest --ignore tests/test_build.py
+"""
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/src/book/_config.yml
+++ b/src/book/_config.yml
@@ -7,8 +7,8 @@ logo: assets/software-gardening-logo.png
 
 #######################################################################################
 # Execution settings
-execute:
-  execute_notebooks: force
+  # avoid executing notebooks to conserve resources
+  execute_notebooks: off
 
 #######################################################################################
 # HTML-specific settings

--- a/src/book/_config.yml
+++ b/src/book/_config.yml
@@ -7,6 +7,7 @@ logo: assets/software-gardening-logo.png
 
 #######################################################################################
 # Execution settings
+execute:
   # avoid executing notebooks to conserve resources
   execute_notebooks: off
 


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR turns off automatic notebook execution for notebooks on builds for docs. After this change I expect the notebooks to render as-is, with the expectation that they are processed before being added to the seedbank or elsewhere. I also added a convenience task through poe which allows for quickly testing package-focused work.

Closes #103 

## What is the nature of your change?

- [ ] Content additions or updates (adds or updates content)
- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own contributions.
- [x] I have commented my content, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to related documentation (outside of book content).
- [x] My changes generate no new warnings.
- [ ] New and existing tests pass locally with my changes.
- [ ] I have added tests that prove my additions are effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
