### PR TITLE
Fix `plotly.js` docsite dependency issue

### DIFF
--- a/src/book/_config.yml
+++ b/src/book/_config.yml
@@ -8,8 +8,7 @@ logo: assets/software-gardening-logo.png
 #######################################################################################
 # Execution settings
 execute:
-  # avoid executing notebooks to conserve resources
-  execute_notebooks: off
+  execute_notebooks: force
 
 #######################################################################################
 # HTML-specific settings


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

After making a change in #104 to disable notebook execution on builds I noticed this resulted in 404's for `plotly.js` which is needed to render the dynamic visuals within https://software-gardening.github.io/almanack/seed-bank/pubmed-github-repositories/visualize-pubmed-repo-sofware-entropy.html . They render as blank frames as a result currently.

![image](https://github.com/user-attachments/assets/d0dce627-5ef6-4c69-bf4f-cd46fb56f602)

This reverts the change for `jupyter-book` configuration to instead execute the notebooks, which in the process adds `plotly.js` as a local script to the HTML file.

Closes #110 

## What is the nature of your change?

- [ ] Content additions or updates (adds or updates content)
- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own contributions.
- [ ] I have commented my content, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to related documentation (outside of book content).
- [x] My changes generate no new warnings.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests that prove my additions are effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
