### PR TITLE
Disable PR entropy report for non-fix branches

### DIFF
--- a/.github/workflows/entropy-check.yml
+++ b/.github/workflows/entropy-check.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   entropy-check:
     runs-on: ubuntu-latest
+    # only run if the PR head branch is named 'fix-gh-actions-pr-report'
+    if: github.event.pull_request.head.ref == 'fix-gh-actions-pr-report'
     permissions: write-all
 
     steps:

--- a/.github/workflows/entropy-check.yml
+++ b/.github/workflows/entropy-check.yml
@@ -3,6 +3,8 @@
 name: entropy-check
 
 on:
+  # note: changed from pull_request_target to help enable if conditional
+  # for workflow.
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/entropy-check.yml
+++ b/.github/workflows/entropy-check.yml
@@ -3,9 +3,8 @@
 name: entropy-check
 
 on:
-  pull_request_target:
-    branches:
-      - main
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/entropy-check.yml
+++ b/.github/workflows/entropy-check.yml
@@ -10,13 +10,13 @@ on:
 
 jobs:
   entropy-check:
+    # only run if the PR head branch is named 'fix-gh-actions-pr-report'
+    if: github.ref == 'refs/heads/fix-gh-actions-pr-report'
     runs-on: ubuntu-latest
     permissions: write-all
 
     steps:
       - name: Checkout code
-        # only run if the PR head branch is named 'fix-gh-actions-pr-report'
-        if: github.event.pull_request.head.ref == 'fix-gh-actions-pr-report'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch the entire history of commits

--- a/.github/workflows/entropy-check.yml
+++ b/.github/workflows/entropy-check.yml
@@ -10,13 +10,13 @@ on:
 
 jobs:
   entropy-check:
-    # only run if the PR head branch is named 'fix-gh-actions-pr-report'
-    if: github.event.pull_request.head.ref == 'fix-gh-actions-pr-report'
     runs-on: ubuntu-latest
     permissions: write-all
 
     steps:
       - name: Checkout code
+        # only run if the PR head branch is named 'fix-gh-actions-pr-report'
+        if: github.event.pull_request.head.ref == 'fix-gh-actions-pr-report'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch the entire history of commits

--- a/.github/workflows/entropy-check.yml
+++ b/.github/workflows/entropy-check.yml
@@ -10,9 +10,9 @@ on:
 
 jobs:
   entropy-check:
-    runs-on: ubuntu-latest
     # only run if the PR head branch is named 'fix-gh-actions-pr-report'
     if: github.event.pull_request.head.ref == 'fix-gh-actions-pr-report'
+    runs-on: ubuntu-latest
     permissions: write-all
 
     steps:


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR disables the `entropy-report` GitHub Action workflow job from being triggered by non-fix branches (those which aren't associated with a fix). Moving forward, PR's which are based on a branch that isn't named `fix-gh-actions-pr-report` will not run the PR report. Branches which do include that name will enable the job to run. This helps dynamically enable a fix for the workflow without disabling it globally. Note: I had to change the trigger to `pull_request` instead of `pull_request_target` in order for the if-conditional to work properly.

CC @willdavidson05 

References #98 
References willdavidson05/almanack#5 , willdavidson05/almanack#3

## What is the nature of your change?

- [ ] Content additions or updates (adds or updates content)
- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own contributions.
- [x] I have commented my content, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to related documentation (outside of book content).
- [x] My changes generate no new warnings.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests that prove my additions are effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
