### PR TITLE
Change test repo branch names from `master` to `main`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
-_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->
+_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/main/.github/PULL_REQUEST_TEMPLATE.md)_ -->
 
 # Description
 

--- a/src/book/garden-circle/contributing.md
+++ b/src/book/garden-circle/contributing.md
@@ -167,5 +167,5 @@ We follow [semantic version](https://en.wikipedia.org/wiki/Software_versioning#S
 
 ## Attribution
 
-We sourced portions of this contribution guide from [`pyctyominer`](https://github.com/cytomining/pycytominer/blob/master/CONTRIBUTING.md).
+We sourced portions of this contribution guide from [`pyctyominer`](https://github.com/cytomining/pycytominer/blob/main/CONTRIBUTING.md).
 Big thanks go to the developers and contributors of that repository.

--- a/tests/data/almanack/repo_setup/create_repo.py
+++ b/tests/data/almanack/repo_setup/create_repo.py
@@ -46,13 +46,16 @@ def commit_changes(repo_path: pathlib.Path, message: str) -> None:
     tree = index.write_tree()
     parent_commit = repo.head.target
     repo.create_commit(
-        "refs/heads/master",  # reference where to commit
+        "refs/heads/main",  # reference where to commit
         signature,  # author
         signature,  # committer
         message,  # commit message
         tree,  # tree object for the commit
         [parent_commit],  # parent commit (list for merge commits)
     )
+
+    # set the head to the main branch
+    repo.set_head("refs/heads/main")
 
 
 def create_repositories(base_path: pathlib.Path) -> None:
@@ -104,13 +107,16 @@ def create_repositories(base_path: pathlib.Path) -> None:
             tree = repo.index.write_tree()
             author = repo.default_signature
             repo.create_commit(
-                "refs/heads/master",  # reference
+                "refs/heads/main",  # reference
                 author,  # author
                 author,  # committer
                 "Committed baseline content to test_repo_1",  # message
                 tree,  # tree object
                 [],  # no parents for initial commit
             )
+
+            # set the head to the main branch
+            repo.set_head("refs/heads/main")
 
         elif repo_name == "1_file_repo":
             md_file = repo_path / "file_1.md"
@@ -129,13 +135,16 @@ def create_repositories(base_path: pathlib.Path) -> None:
             tree = repo.index.write_tree()
             author = repo.default_signature
             repo.create_commit(
-                "refs/heads/master",  # reference
+                "refs/heads/main",  # reference
                 author,  # author
                 author,  # committer
                 "Committed baseline content to test_repo_2",  # message
                 tree,  # tree object
                 [],  # no parents for initial commit
             )
+
+            # set the head to the main branch
+            repo.set_head("refs/heads/main")
 
     # Run the add_entropy.py module to insert additional lines
     add_LOC(base_path)


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR changes references to the `master` branch to be `main` instead within testing repositories. This is a step towards inclusive language usage and aligns with software best practices more broadly. Along with this I also updated places within various documentation where `master` references have been updated to `main`.

Thanks for any feedback!

Closes #116 

## What is the nature of your change?

- [ ] Content additions or updates (adds or updates content)
- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own contributions.
- [x] I have commented my content, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to related documentation (outside of book content).
- [x] My changes generate no new warnings.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests that prove my additions are effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
