### PR TITLE
Deduplicate metric key usage to simplify development

### DIFF
--- a/src/almanack/metrics/data.py
+++ b/src/almanack/metrics/data.py
@@ -59,7 +59,7 @@ def get_table(repo_path: str) -> Dict[str, Any]:
             # remove the result-data-key as this won't be useful to external output
             **{key: val for key, val in metric.items() if key != "result-data-key"},
             # add the data results for the metrics to the table
-            "result": data[metric["result-data-key"]],
+            "result": data[metric["name"]],
         }
         # for each metric, gather the related process data and add to a dictionary
         # related to that metric along with others in a list.
@@ -214,29 +214,29 @@ def compute_repo_data(repo_path: str) -> None:
 
         # Return the data structure
         return {
-            "repo_path": str(repo_path),
-            "number_of_commits": len(commits),
-            "number_of_files": len(file_names),
-            "time_range_of_commits": (first_commit_date, most_recent_commit_date),
-            "readme-included": file_exists_in_repo(
+            "repo-path": str(repo_path),
+            "repo-commits": len(commits),
+            "repo-file-count": len(file_names),
+            "repo-commit-time-range": (first_commit_date, most_recent_commit_date),
+            "includes-readme": file_exists_in_repo(
                 repo=repo,
                 expected_file_name="readme",
             ),
-            "contributing-included": file_exists_in_repo(
+            "includes-contributing": file_exists_in_repo(
                 repo=repo,
                 expected_file_name="contributing",
             ),
-            "code-of-conduct-included": file_exists_in_repo(
+            "includes-code-of-conduct": file_exists_in_repo(
                 repo=repo,
                 expected_file_name="code_of_conduct",
             ),
-            "license-included": file_exists_in_repo(
+            "includes-license": file_exists_in_repo(
                 repo=repo,
                 expected_file_name="license",
             ),
             "is-citable": is_citable(repo=repo),
-            "normalized_total_entropy": normalized_total_entropy,
-            "file_level_entropy": file_entropy,
+            "agg-info-entropy": normalized_total_entropy,
+            "file-info-entropy": file_entropy,
         }
 
     except Exception as e:

--- a/src/almanack/metrics/data.py
+++ b/src/almanack/metrics/data.py
@@ -218,25 +218,25 @@ def compute_repo_data(repo_path: str) -> None:
             "repo-commits": len(commits),
             "repo-file-count": len(file_names),
             "repo-commit-time-range": (first_commit_date, most_recent_commit_date),
-            "includes-readme": file_exists_in_repo(
+            "repo-includes-readme": file_exists_in_repo(
                 repo=repo,
                 expected_file_name="readme",
             ),
-            "includes-contributing": file_exists_in_repo(
+            "repo-includes-contributing": file_exists_in_repo(
                 repo=repo,
                 expected_file_name="contributing",
             ),
-            "includes-code-of-conduct": file_exists_in_repo(
+            "repo-includes-code-of-conduct": file_exists_in_repo(
                 repo=repo,
                 expected_file_name="code_of_conduct",
             ),
-            "includes-license": file_exists_in_repo(
+            "repo-includes-license": file_exists_in_repo(
                 repo=repo,
                 expected_file_name="license",
             ),
-            "is-citable": is_citable(repo=repo),
-            "agg-info-entropy": normalized_total_entropy,
-            "file-info-entropy": file_entropy,
+            "repo-is-citable": is_citable(repo=repo),
+            "repo-agg-info-entropy": normalized_total_entropy,
+            "repo-file-info-entropy": file_entropy,
         }
 
     except Exception as e:

--- a/src/almanack/metrics/metrics.yml
+++ b/src/almanack/metrics/metrics.yml
@@ -20,37 +20,37 @@ metrics:
     result-type: "tuple"
     description: >-
       Starting commit and most recent commit for the repository.
-  - name: "includes-readme"
+  - name: "repo-includes-readme"
     id: "SGA-GL-0001"
     result-type: "bool"
     description: >-
       Boolean value indicating the presence of a README file
       in the repository.
-  - name: "includes-contributing"
+  - name: "repo-includes-contributing"
     id: "SGA-GL-0002"
     result-type: "bool"
     description: >-
       Boolean value indicating the presence of a CONTRIBUTING file
       in the repository.
-  - name: "includes-code-of-conduct"
+  - name: "repo-includes-code-of-conduct"
     id: "SGA-GL-0003"
     result-type: "bool"
     description: >-
       Boolean value indicating the presence of a CODE_OF_CONDUCT file
       in the repository.
-  - name: "includes-license"
+  - name: "repo-includes-license"
     id: "SGA-GL-0004"
     result-type: "bool"
     description: >-
       Boolean value indicating the presence of a LICENSE file
       in the repository.
-  - name: "is-citable"
+  - name: "repo-is-citable"
     id: "SGA-GL-0005"
     result-type: "bool"
     description: >-
       Boolean value indicating the presence of a CITATION file
       or some other means of indicating how to cite the work.
-  - name: "agg-info-entropy"
+  - name: "repo-agg-info-entropy"
     id: "SGA-VS-0001"
     result-type: "float"
     description: >-
@@ -59,7 +59,7 @@ metrics:
       latest commits). Represents value from 0 to 1 where 0 equals
       no information entropy and 1 represents maximum information
       entropy.
-  - name: "file-info-entropy"
+  - name: "repo-file-info-entropy"
     id: "SGA-VS-0002"
     result-type: "dict"
     description: >-

--- a/src/almanack/metrics/metrics.yml
+++ b/src/almanack/metrics/metrics.yml
@@ -3,66 +3,56 @@ metrics:
   - name: "repo-path"
     id: "SGA-META-0001"
     result-type: "str"
-    result-data-key: "repo_path"
     description: >-
       Repository path (local directory).
   - name: "repo-commits"
     id: "SGA-META-0002"
     result-type: "int"
-    result-data-key: "number_of_commits"
     description: >-
       Total number of commits for the repository.
   - name: "repo-file-count"
     id: "SGA-META-0003"
     result-type: "int"
-    result-data-key: "number_of_files"
     description: >-
       Total number of files tracked within the repository.
   - name: "repo-commit-time-range"
     id: "SGA-META-0004"
     result-type: "tuple"
-    result-data-key: "time_range_of_commits"
     description: >-
       Starting commit and most recent commit for the repository.
   - name: "includes-readme"
     id: "SGA-GL-0001"
     result-type: "bool"
-    result-data-key: "readme-included"
     description: >-
       Boolean value indicating the presence of a README file
       in the repository.
   - name: "includes-contributing"
     id: "SGA-GL-0002"
     result-type: "bool"
-    result-data-key: "contributing-included"
     description: >-
       Boolean value indicating the presence of a CONTRIBUTING file
       in the repository.
   - name: "includes-code-of-conduct"
     id: "SGA-GL-0003"
     result-type: "bool"
-    result-data-key: "code-of-conduct-included"
     description: >-
       Boolean value indicating the presence of a CODE_OF_CONDUCT file
       in the repository.
   - name: "includes-license"
     id: "SGA-GL-0004"
     result-type: "bool"
-    result-data-key: "license-included"
     description: >-
       Boolean value indicating the presence of a LICENSE file
       in the repository.
   - name: "is-citable"
     id: "SGA-GL-0005"
     result-type: "bool"
-    result-data-key: "is-citable"
     description: >-
       Boolean value indicating the presence of a CITATION file
       or some other means of indicating how to cite the work.
   - name: "agg-info-entropy"
     id: "SGA-VS-0001"
     result-type: "float"
-    result-data-key: "normalized_total_entropy"
     description: >-
       Aggregated information entropy for all files within a repository
       given a range between two commits (by default, the first and
@@ -72,7 +62,6 @@ metrics:
   - name: "file-info-entropy"
     id: "SGA-VS-0002"
     result-type: "dict"
-    result-data-key: "file_level_entropy"
     description: >-
       File-level information entropy for all files within a repository
       given a range between two commits (by default, the first and

--- a/tests/metrics/test_data.py
+++ b/tests/metrics/test_data.py
@@ -35,21 +35,22 @@ def test_generate_repo_data(entropy_repository_paths: dict[str, pathlib.Path]) -
 
         # Check for expected keys
         expected_keys = [
-            "repo_path",
-            "number_of_commits",
-            "number_of_files",
-            "time_range_of_commits",
-            "readme-included",
-            "contributing-included",
-            "code-of-conduct-included",
-            "license-included",
-            "normalized_total_entropy",
-            "file_level_entropy",
+            "repo-path",
+            "repo-commits",
+            "repo-file-count",
+            "repo-commit-time-range",
+            "includes-readme",
+            "includes-contributing",
+            "includes-code-of-conduct",
+            "includes-license",
+            "is-citable",
+            "agg-info-entropy",
+            "file-info-entropy",
         ]
         assert all(key in data for key in expected_keys)
 
         # Check that repo_path in the output is the same as the input
-        assert data["repo_path"] == str(repo_path)
+        assert data["repo-path"] == str(repo_path)
 
 
 def test_get_table(entropy_repository_paths: dict[str, pathlib.Path]) -> None:
@@ -92,14 +93,12 @@ def test_metrics_yaml():
                         "name": {"type": "string"},
                         "id": {"type": "string"},
                         "result-type": {"type": "string"},
-                        "result-data-key": {"type": "string"},
                         "description": {"type": "string"},
                     },
                     "required": [
                         "name",
                         "id",
                         "result-type",
-                        "result-data-key",
                         "description",
                     ],
                 },

--- a/tests/metrics/test_data.py
+++ b/tests/metrics/test_data.py
@@ -39,13 +39,13 @@ def test_generate_repo_data(entropy_repository_paths: dict[str, pathlib.Path]) -
             "repo-commits",
             "repo-file-count",
             "repo-commit-time-range",
-            "includes-readme",
-            "includes-contributing",
-            "includes-code-of-conduct",
-            "includes-license",
-            "is-citable",
-            "agg-info-entropy",
-            "file-info-entropy",
+            "repo-includes-readme",
+            "repo-includes-contributing",
+            "repo-includes-code-of-conduct",
+            "repo-includes-license",
+            "repo-is-citable",
+            "repo-agg-info-entropy",
+            "repo-file-info-entropy",
         ]
         assert all(key in data for key in expected_keys)
 


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/main/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR deduplicates the use of metric key "names" to help simplify development. Initially a key was used for naming the metric and then referencing a separate value within the generated results. This change merges the use of these to use only the "name" key as a reference point (there's not a need to abstract further). This should simplify development over time and shrink the size of the metrics yaml file.

Closes #124 

## What is the nature of your change?

- [ ] Content additions or updates (adds or updates content)
- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own contributions.
- [x] I have commented my content, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to related documentation (outside of book content).
- [x] My changes generate no new warnings.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests that prove my additions are effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
