### PR TITLE
Add metric for checking common documentation paths

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,0 +1,3 @@
+# Documentation
+
+Please find our documentation within the [`src/book`](lmanack/tree/main/src/book) directory for the source or via [https://software-gardening.github.io/almanack](https://software-gardening.github.io/almanack).

--- a/src/almanack/metrics/data.py
+++ b/src/almanack/metrics/data.py
@@ -141,7 +141,9 @@ def is_citable(repo: pygit2.Repository) -> bool:
 
     # Look for a README.md file and read its content
     if (
-        file_content := find_and_read_file(repo=repo, filename="readme.md")
+        file_content := find_and_read_file(
+            repo=repo, filepath="readme.md", case_insensitive=True
+        )
     ) is not None:
         # Check for an H2 heading indicating a citation section
         if any(
@@ -191,6 +193,36 @@ def default_branch_is_not_master(repo: pygit2.Repository) -> bool:
         # If "refs/remotes/origin/HEAD" or "refs/remotes/origin/master" doesn't exist,
         # fall back to the local HEAD check
         return repo.head.shorthand != "master"
+
+
+def includes_common_docs(repo: pygit2.Repository) -> bool:
+    """
+    Check whether the repo includes common documentation files and directories
+    associated with building docsites.
+
+    Args:
+        repo (pygit2.Repository): The repository object.
+
+    Returns:
+        bool: True if any common documentation files are found, False otherwise.
+    """
+    # List of common documentation file paths to check for
+    common_docs_paths = [
+        "docs/mkdocs.yml",
+        "docs/conf.py",
+        "docs/index.md",
+        "docs/index.rst",
+        "docs/index.html",
+        "docs/readme.md",
+    ]
+
+    # Check each documentation path using the find_and_read_file function
+    for doc_path in common_docs_paths:
+        if find_and_read_file(repo=repo, filepath=doc_path) is not None:
+            return True  # Return True as soon as we find any of the files
+
+    # otherwise return false as we didn't find documentation
+    return False
 
 
 def compute_repo_data(repo_path: str) -> None:
@@ -263,6 +295,7 @@ def compute_repo_data(repo_path: str) -> None:
             ),
             "repo-is-citable": is_citable(repo=repo),
             "repo-default-branch-not-master": default_branch_is_not_master(repo=repo),
+            "repo-includes-common-docs": includes_common_docs(repo=repo),
             "repo-agg-info-entropy": normalized_total_entropy,
             "repo-file-info-entropy": file_entropy,
         }

--- a/src/almanack/metrics/data.py
+++ b/src/almanack/metrics/data.py
@@ -214,6 +214,12 @@ def includes_common_docs(repo: pygit2.Repository) -> bool:
         "docs/index.rst",
         "docs/index.html",
         "docs/readme.md",
+        "docs/source/readme.md",
+        "docs/source/index.rst",
+        "docs/source/index.md",
+        "docs/src/readme.md",
+        "docs/src/index.rst",
+        "docs/src/index.md",
     ]
 
     # Check each documentation path using the find_and_read_file function

--- a/src/almanack/metrics/data.py
+++ b/src/almanack/metrics/data.py
@@ -201,10 +201,13 @@ def includes_common_docs(repo: pygit2.Repository) -> bool:
     associated with building docsites.
 
     Args:
-        repo (pygit2.Repository): The repository object.
+        repo (pygit2.Repository):
+            The repository object.
 
     Returns:
-        bool: True if any common documentation files are found, False otherwise.
+        bool:
+            True if any common documentation files
+            are found, False otherwise.
     """
     # List of common documentation file paths to check for
     common_docs_paths = [

--- a/src/almanack/metrics/data.py
+++ b/src/almanack/metrics/data.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional, Tuple
 import pygit2
 import yaml
 
-from ..git import clone_repository, find_and_read_file, get_commits, get_edited_files
+from ..git import clone_repository, find_file, get_commits, get_edited_files, read_file
 from .entropy.calculate_entropy import (
     calculate_aggregate_entropy,
     calculate_normalized_entropy,
@@ -141,7 +141,7 @@ def is_citable(repo: pygit2.Repository) -> bool:
 
     # Look for a README.md file and read its content
     if (
-        file_content := find_and_read_file(
+        file_content := read_file(
             repo=repo, filepath="readme.md", case_insensitive=True
         )
     ) is not None:
@@ -225,9 +225,9 @@ def includes_common_docs(repo: pygit2.Repository) -> bool:
         "docs/src/index.md",
     ]
 
-    # Check each documentation path using the find_and_read_file function
+    # Check each documentation path using the find_file function
     for doc_path in common_docs_paths:
-        if find_and_read_file(repo=repo, filepath=doc_path) is not None:
+        if find_file(repo=repo, filepath=doc_path) is not None:
             return True  # Return True as soon as we find any of the files
 
     # otherwise return false as we didn't find documentation

--- a/src/almanack/metrics/metrics.yml
+++ b/src/almanack/metrics/metrics.yml
@@ -56,6 +56,13 @@ metrics:
     description: >-
       Boolean value indicating that the repo uses a
       default branch name besides 'master'.
+  - name: "repo-includes-common-docs"
+    id: "SGA-GL-0007"
+    result-type: "bool"
+    description: >-
+      Boolean value indicating whether the repo includes
+      common documentation directory and files associated
+      with building docsites.
   - name: "repo-agg-info-entropy"
     id: "SGA-VS-0001"
     result-type: "float"

--- a/tests/data/almanack/repo_setup/create_repo.py
+++ b/tests/data/almanack/repo_setup/create_repo.py
@@ -159,7 +159,17 @@ def repo_setup(
     repo_path: pathlib.Path, files: dict, branch_name: str = "main"
 ) -> pygit2.Repository:
     """
-    Set up a temporary repository with specified files, supporting nested file paths.
+    Set up a temporary repository with specified files.
+    Args:
+        repo_path (Path):
+            The directory where the repo will be created.
+        files (dict):
+            A dictionary where keys are filenames and values are their content.
+        branch_name (str):
+            A string with the name of the branch which will be used for
+            committing changes. Defaults to "main".
+    Returns:
+        pygit2.Repository: The initialized repository with files.
     """
     # Create a new repository in the specified path
     repo = pygit2.init_repository(repo_path, bare=False)

--- a/tests/data/almanack/repo_setup/create_repo.py
+++ b/tests/data/almanack/repo_setup/create_repo.py
@@ -159,29 +159,21 @@ def repo_setup(
     repo_path: pathlib.Path, files: dict, branch_name: str = "main"
 ) -> pygit2.Repository:
     """
-    Set up a temporary repository with specified files.
-
-    Args:
-        tmp_path (Path):
-            The temporary directory where the repo will be created.
-        files (dict):
-            A dictionary where keys are filenames and values are their content.
-        branch_name (str):
-            A string with the name of the branch which will be used for
-            committing changes. Defaults to "main".
-
-    Returns:
-        pygit2.Repository: The initialized repository with files.
+    Set up a temporary repository with specified files, supporting nested file paths.
     """
-    # Create a new repository in the temporary path
+    # Create a new repository in the specified path
     repo = pygit2.init_repository(repo_path, bare=False)
 
     # Set user.name and user.email in the config
     set_repo_user_config(repo)
 
-    # Create files in the repository
-    for filename, content in files.items():
-        (repo_path / filename).write_text(content)
+    # Create nested files in the repository
+    for file_path, content in files.items():
+        full_path = repo_path / file_path  # Construct full path
+        full_path.parent.mkdir(
+            parents=True, exist_ok=True
+        )  # Create any parent directories
+        full_path.write_text(content)  # Write the file content
 
     # Stage and commit the files
     index = repo.index
@@ -191,6 +183,7 @@ def repo_setup(
     author = repo.default_signature
     tree = repo.index.write_tree()
 
+    # Commit the files
     repo.create_commit(
         f"refs/heads/{branch_name}",
         author,
@@ -200,7 +193,7 @@ def repo_setup(
         [],
     )
 
-    # Set the head to the main branch
+    # Set the HEAD to point to the new branch
     repo.set_head(f"refs/heads/{branch_name}")
 
     return repo

--- a/tests/metrics/test_data.py
+++ b/tests/metrics/test_data.py
@@ -344,7 +344,7 @@ def test_default_branch_is_not_master(tmp_path):
             False,
         ),
         # test the almanack itseft as a special case
-        (None, None),
+        (None, True),
     ],
 )
 def test_includes_common_docs(tmp_path, files, expected_result):

--- a/tests/metrics/test_data.py
+++ b/tests/metrics/test_data.py
@@ -17,6 +17,7 @@ from almanack.metrics.data import (
     default_branch_is_not_master,
     file_exists_in_repo,
     get_table,
+    includes_common_docs,
     is_citable,
 )
 from tests.data.almanack.repo_setup.create_repo import repo_setup
@@ -34,21 +35,19 @@ def test_generate_repo_data(entropy_repository_paths: dict[str, pathlib.Path]) -
         assert data is not None
         assert isinstance(data, dict)
 
-        # Check for expected keys
-        expected_keys = [
-            "repo-path",
-            "repo-commits",
-            "repo-file-count",
-            "repo-commit-time-range",
-            "repo-includes-readme",
-            "repo-includes-contributing",
-            "repo-includes-code-of-conduct",
-            "repo-includes-license",
-            "repo-is-citable",
-            "repo-agg-info-entropy",
-            "repo-file-info-entropy",
-        ]
-        assert all(key in data for key in expected_keys)
+        # open the metrics table
+        with open(METRICS_TABLE, "r") as f:
+            metrics_table = yaml.safe_load(f)
+
+        # check that all keys exist in the output from metrics
+        # table to received dict
+        assert all(
+            x == y
+            for x, y in zip(
+                sorted(data.keys()),
+                sorted([metric["name"] for metric in metrics_table["metrics"]]),
+            )
+        )
 
         # Check that repo_path in the output is the same as the input
         assert data["repo-path"] == str(repo_path)
@@ -306,3 +305,57 @@ def test_default_branch_is_not_master(tmp_path):
     )
 
     assert not default_branch_is_not_master(repo)
+
+
+@pytest.mark.parametrize(
+    "files, expected_result",
+    [
+        # Scenario 1: `docs` directory with common documentation files
+        (
+            {
+                "docs/mkdocs.yml": "site_name: Test Docs",
+                "docs/index.md": "# Welcome to the documentation",
+                "README.md": "# Project Overview",
+            },
+            True,
+        ),
+        # Scenario 2: `docs` directory without common documentation files
+        (
+            {
+                "docs/random_file.txt": "This is just a random file",
+                "README.md": "# Project Overview",
+            },
+            False,
+        ),
+        # Scenario 3: No `docs` directory
+        (
+            {
+                "README.md": "# Project Overview",
+                "src/main.py": "# Main script",
+            },
+            False,
+        ),
+        # Scenario 4: `docs` directory with misleading names
+        (
+            {
+                "docs/mkdoc.yml": "Not a valid mkdocs file",
+                "docs/INDEX.md": "# Not a documentation index",
+            },
+            False,
+        ),
+        # test the almanack itseft as a special case
+        (None, None),
+    ],
+)
+def test_includes_common_docs(tmp_path, files, expected_result):
+    # Temporary directory for the test repository
+
+    if files is not None:
+        repo = repo_setup(repo_path=tmp_path, files=files)
+    else:
+        # test the almanack itself
+        repo_path = pathlib.Path(".").resolve()
+        repo = pygit2.Repository(str(repo_path))
+
+    # Assert that the function returns the expected result
+    assert includes_common_docs(repo) == expected_result

--- a/tests/metrics/test_data.py
+++ b/tests/metrics/test_data.py
@@ -343,6 +343,27 @@ def test_default_branch_is_not_master(tmp_path):
             },
             False,
         ),
+        # Scenario 5: `docs` directory with sphinx-like structure
+        (
+            {
+                "docs/source/index.rst": "An rst index",
+            },
+            True,
+        ),
+        # Scenario 6: `docs` directory with sphinx-like structure
+        (
+            {
+                "docs/source/index.md": "An md index",
+            },
+            True,
+        ),
+        # Scenario 6: `docs` directory with a readme under source dir
+        (
+            {
+                "docs/source/readme.md": "A readme for nested docs",
+            },
+            True,
+        ),
         # test the almanack itseft as a special case
         (None, True),
     ],

--- a/tests/metrics/test_data.py
+++ b/tests/metrics/test_data.py
@@ -369,8 +369,9 @@ def test_default_branch_is_not_master(tmp_path):
     ],
 )
 def test_includes_common_docs(tmp_path, files, expected_result):
-    # Temporary directory for the test repository
-
+    """
+    Tests includes_common_docs
+    """
     if files is not None:
         repo = repo_setup(repo_path=tmp_path, files=files)
     else:

--- a/tests/metrics/test_data.py
+++ b/tests/metrics/test_data.py
@@ -41,13 +41,7 @@ def test_generate_repo_data(entropy_repository_paths: dict[str, pathlib.Path]) -
 
         # check that all keys exist in the output from metrics
         # table to received dict
-        assert all(
-            x == y
-            for x, y in zip(
-                sorted(data.keys()),
-                sorted([metric["name"] for metric in metrics_table["metrics"]]),
-            )
-        )
+        assert sorted(data.keys()) == sorted([metric["name"] for metric in metrics_table["metrics"]])
 
         # Check that repo_path in the output is the same as the input
         assert data["repo-path"] == str(repo_path)

--- a/tests/metrics/test_data.py
+++ b/tests/metrics/test_data.py
@@ -41,7 +41,9 @@ def test_generate_repo_data(entropy_repository_paths: dict[str, pathlib.Path]) -
 
         # check that all keys exist in the output from metrics
         # table to received dict
-        assert sorted(data.keys()) == sorted([metric["name"] for metric in metrics_table["metrics"]])
+        assert sorted(data.keys()) == sorted(
+            [metric["name"] for metric in metrics_table["metrics"]]
+        )
 
         # Check that repo_path in the output is the same as the input
         assert data["repo-path"] == str(repo_path)


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/main/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR adds a metric which checks for "common documentation" paths within a given repository. We perform this measurement in alignment with #150. As part of measuring how the Almanack itself meets this standard I created a docs directory with a reference to where to find the documentation for this project. As a minor note to this effect, the `book` content is currently stored within the `src` as it is included with the package builds for reading through the Python package.

I feel we could continue to work on #150 with another change after this which involves looking at common GitHub Pages locations based on the git remotes listing of a repository (which would likely yield an HTTP link we could use to form the default GitHub pages default). We could also check for docs badging within the main readme. Either way, I thought these changes might be better outside this PR, as they're a bit different in nature.

References #150

## What is the nature of your change?

- [ ] Content additions or updates (adds or updates content)
- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own contributions.
- [x] I have commented my content, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to related documentation (outside of book content).
- [x] My changes generate no new warnings.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests that prove my additions are effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
