### PR TITLE
Avoid detached head state with dependabot changes

### DIFF
--- a/.github/workflows/dependabot-pre-commit.yaml
+++ b/.github/workflows/dependabot-pre-commit.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
+          fetch-depth: 0
       - name: Install python env
         uses: ./.github/actions/install-python-env
         with:


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/main/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This is a follow up to #171 after seeing the error in https://github.com/software-gardening/almanack/actions/runs/11800265956/job/32870771815?pr=169 to help fix the detached head state. `checkout` by default will avoid gathering the full git history of a branch in an effort to be efficient but I believe this leads to a detached head state and the error in the job run. This change attempts to remedy this.

## What is the nature of your change?

- [ ] Content additions or updates (adds or updates content)
- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own contributions.
- [ ] I have commented my content, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to related documentation (outside of book content).
- [x] My changes generate no new warnings.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests that prove my additions are effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
