### PR TITLE
Add metrics for unique and active contributor counts

### DIFF
--- a/src/almanack/metrics/data.py
+++ b/src/almanack/metrics/data.py
@@ -5,7 +5,7 @@ This module computes data for GitHub Repositories
 import pathlib
 import shutil
 import tempfile
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
 import pygit2
@@ -25,7 +25,7 @@ from .entropy.calculate_entropy import (
 )
 
 METRICS_TABLE = f"{pathlib.Path(__file__).parent!s}/metrics.yml"
-
+DATETIME_NOW = datetime.now(timezone.utc)
 
 def get_table(repo_path: str) -> List[Dict[str, Any]]:
     """
@@ -275,6 +275,33 @@ def includes_common_docs(repo: pygit2.Repository) -> bool:
     # otherwise return false as we didn't find documentation
     return False
 
+def count_unique_contributors(repo: pygit2.Repository, since: Optional[datetime] = None) -> int:
+    """
+    Counts the number of unique contributors to a repository.
+
+    If a `since` datetime is provided, counts contributors 
+    who made commits after the specified datetime. 
+    Otherwise, counts all contributors.
+
+    Args:
+        repo (pygit2.Repository):
+            The repository to analyze.
+        since (Optional[datetime]):
+            The cutoff datetime. Only contributions after
+            this datetime are counted. If None, all 
+            contributions are considered.
+
+    Returns:
+        int:
+            The number of unique contributors.
+    """
+    since_timestamp = since.timestamp() if since else 0
+    contributors = {
+        commit.author.email
+        for commit in repo.walk(repo.head.target, pygit2.GIT_SORT_TIME)
+        if commit.commit_time > since_timestamp
+    }
+    return len(contributors)
 
 def compute_repo_data(repo_path: str) -> None:
     """
@@ -333,6 +360,7 @@ def compute_repo_data(repo_path: str) -> None:
             + 1
         ),
         "repo-commits-per-day": commits_count / days_of_development,
+        "almanack-table-datetime": DATETIME_NOW.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
         "repo-includes-readme": file_exists_in_repo(
             repo=repo,
             expected_file_name="readme",
@@ -352,6 +380,9 @@ def compute_repo_data(repo_path: str) -> None:
         "repo-is-citable": is_citable(repo=repo),
         "repo-default-branch-not-master": default_branch_is_not_master(repo=repo),
         "repo-includes-common-docs": includes_common_docs(repo=repo),
+        "repo-unique-contributors": count_unique_contributors(repo=repo),
+        "repo-unique-contributors-past-year": count_unique_contributors(repo=repo, since=DATETIME_NOW - timedelta(days=365)),
+        "repo-unique-contributors-past-182-days": count_unique_contributors(repo=repo, since=DATETIME_NOW - timedelta(days=182)),
         "repo-agg-info-entropy": normalized_total_entropy,
         "repo-file-info-entropy": file_entropy,
     }

--- a/src/almanack/metrics/data.py
+++ b/src/almanack/metrics/data.py
@@ -5,7 +5,7 @@ This module computes data for GitHub Repositories
 import pathlib
 import shutil
 import tempfile
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 import pygit2
@@ -26,6 +26,7 @@ from .entropy.calculate_entropy import (
 
 METRICS_TABLE = f"{pathlib.Path(__file__).parent!s}/metrics.yml"
 DATETIME_NOW = datetime.now(timezone.utc)
+
 
 def get_table(repo_path: str) -> List[Dict[str, Any]]:
     """
@@ -275,12 +276,15 @@ def includes_common_docs(repo: pygit2.Repository) -> bool:
     # otherwise return false as we didn't find documentation
     return False
 
-def count_unique_contributors(repo: pygit2.Repository, since: Optional[datetime] = None) -> int:
+
+def count_unique_contributors(
+    repo: pygit2.Repository, since: Optional[datetime] = None
+) -> int:
     """
     Counts the number of unique contributors to a repository.
 
-    If a `since` datetime is provided, counts contributors 
-    who made commits after the specified datetime. 
+    If a `since` datetime is provided, counts contributors
+    who made commits after the specified datetime.
     Otherwise, counts all contributors.
 
     Args:
@@ -288,7 +292,7 @@ def count_unique_contributors(repo: pygit2.Repository, since: Optional[datetime]
             The repository to analyze.
         since (Optional[datetime]):
             The cutoff datetime. Only contributions after
-            this datetime are counted. If None, all 
+            this datetime are counted. If None, all
             contributions are considered.
 
     Returns:
@@ -302,6 +306,7 @@ def count_unique_contributors(repo: pygit2.Repository, since: Optional[datetime]
         if commit.commit_time > since_timestamp
     }
     return len(contributors)
+
 
 def compute_repo_data(repo_path: str) -> None:
     """
@@ -360,7 +365,7 @@ def compute_repo_data(repo_path: str) -> None:
             + 1
         ),
         "repo-commits-per-day": commits_count / days_of_development,
-        "almanack-table-datetime": DATETIME_NOW.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+        "almanack-table-datetime": DATETIME_NOW.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
         "repo-includes-readme": file_exists_in_repo(
             repo=repo,
             expected_file_name="readme",
@@ -381,8 +386,12 @@ def compute_repo_data(repo_path: str) -> None:
         "repo-default-branch-not-master": default_branch_is_not_master(repo=repo),
         "repo-includes-common-docs": includes_common_docs(repo=repo),
         "repo-unique-contributors": count_unique_contributors(repo=repo),
-        "repo-unique-contributors-past-year": count_unique_contributors(repo=repo, since=DATETIME_NOW - timedelta(days=365)),
-        "repo-unique-contributors-past-182-days": count_unique_contributors(repo=repo, since=DATETIME_NOW - timedelta(days=182)),
+        "repo-unique-contributors-past-year": count_unique_contributors(
+            repo=repo, since=DATETIME_NOW - timedelta(days=365)
+        ),
+        "repo-unique-contributors-past-182-days": count_unique_contributors(
+            repo=repo, since=DATETIME_NOW - timedelta(days=182)
+        ),
         "repo-agg-info-entropy": normalized_total_entropy,
         "repo-file-info-entropy": file_entropy,
     }

--- a/src/almanack/metrics/metrics.yml
+++ b/src/almanack/metrics/metrics.yml
@@ -32,6 +32,13 @@ metrics:
     description: >-
       Floating point number which represents the number of commits
       per day (using days of development).
+  - name: "almanack-table-datetime"
+    id: "SGA-META-0007"
+    result-type: "string"
+    description: >-
+      String representing the date when this table was generated
+      in the format of '%Y-%m-%dT%H:%M:%S.%fZ', for example:
+      2024-11-22T18:20:30.123456Z .
   - name: "repo-includes-readme"
     id: "SGA-GL-0001"
     result-type: "bool"
@@ -75,6 +82,26 @@ metrics:
       Boolean value indicating whether the repo includes
       common documentation directory and files associated
       with building docsites.
+  - name: "repo-unique-contributors"
+    id: "SGA-GL-0008"
+    result-type: "int"
+    description: >-
+      Count of unique contributors since the beginning
+      of the repository.
+  - name: "repo-unique-contributors-past-year"
+    id: "SGA-GL-0009"
+    result-type: "int"
+    description: >-
+      Count of unique contributors within the last year
+      from now (where now is a reference to table value
+      of almanack-table-datetime).
+  - name: "repo-unique-contributors-past-182-days"
+    id: "SGA-GL-0010"
+    result-type: "int"
+    description: >-
+      Count of unique contributors within the last 182 days
+      from now (where now is a reference to table value
+      of almanack-table-datetime).
   - name: "repo-agg-info-entropy"
     id: "SGA-VS-0001"
     result-type: "float"

--- a/tests/data/almanack/repo_setup/create_repo.py
+++ b/tests/data/almanack/repo_setup/create_repo.py
@@ -202,7 +202,9 @@ def repo_setup(
         # Create or update each file in the current commit
         for filename, content in commit_files.items():
             file_path = repo_path / filename
-            file_path.parent.mkdir(parents=True, exist_ok=True)  # Ensure parent directories exist
+            file_path.parent.mkdir(
+                parents=True, exist_ok=True
+            )  # Ensure parent directories exist
             file_path.write_text(content)
 
         # Stage all changes in the index
@@ -231,16 +233,22 @@ def repo_setup(
         # Create the commit
         commit_message = f"Commit #{i + 1} with files: {', '.join(commit_files.keys())}"
         commit_id = repo.create_commit(
-            branch_ref if i == 0 else None,  # Set branch reference only for the first commit
+            (
+                branch_ref if i == 0 else None
+            ),  # Set branch reference only for the first commit
             author,
             committer,
             commit_message,
             tree,
-            [parent_commit.id] if parent_commit else [],  # Use the .id attribute to get the commit ID
+            (
+                [parent_commit.id] if parent_commit else []
+            ),  # Use the .id attribute to get the commit ID
         )
 
         # Update the parent_commit to the latest commit for chaining
-        parent_commit = repo.get(commit_id)  # Explicitly get the Commit object by its ID
+        parent_commit = repo.get(
+            commit_id
+        )  # Explicitly get the Commit object by its ID
 
     # Set the HEAD to the main branch after all commits
     repo.set_head(branch_ref)


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/main/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR adds metrics which count unique contributors in various ways. I use this to help interpret "active contributors" by looking at the number of unique contributors within the last year and 182 days (roughly half a year). In addition, I also added a metadata field which allows the table contents to have a relative datetime stamp which may be useful for understanding the unique contributors per 1 year and per 182 days since the time the table was generated.

Thanks for any feedback!

Closes #159 

## What is the nature of your change?

- [ ] Content additions or updates (adds or updates content)
- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own contributions.
- [x] I have commented my content, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to related documentation (outside of book content).
- [x] My changes generate no new warnings.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests that prove my additions are effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
