### PR TITLE
Add metric for repo tag count

### DIFF
--- a/src/almanack/metrics/data.py
+++ b/src/almanack/metrics/data.py
@@ -308,19 +308,42 @@ def count_unique_contributors(
     return len(contributors)
 
 
-def count_repo_tags(repo: pygit2.Repository) -> int:
+def count_repo_tags(repo: pygit2.Repository, since: Optional[datetime] = None) -> int:
     """
     Counts the number of tags in a pygit2 repository.
+
+    If a `since` datetime is provided, counts only tags associated
+    with commits made after the specified datetime. Otherwise,
+    counts all tags in the repository.
 
     Args:
         repo (pygit2.Repository):
             The repository to analyze.
+        since (Optional[datetime]):
+            The cutoff datetime. Only tags for commits after
+            this datetime are counted. If None, all tags are counted.
 
     Returns:
         int:
-            The number of tags in the repository.
+            The number of tags in the repository that meet the criteria.
     """
-    return sum(1 for ref in repo.references if ref.startswith("refs/tags/"))
+    since_timestamp = since.timestamp() if since else 0
+
+    count = 0
+    for ref in repo.references:
+        if ref.startswith("refs/tags/"):
+            tag = repo.lookup_reference(ref)
+            target_commit = repo[tag.target]
+
+            # Consider lightweight or annotated tags
+            if target_commit.type == pygit2.GIT_OBJECT_TAG:
+                target_commit = repo[target_commit.target]
+
+            # Check commit timestamp against `since`
+            if target_commit.commit_time > since_timestamp:
+                count += 1
+
+    return count
 
 
 def compute_repo_data(repo_path: str) -> None:
@@ -403,12 +426,16 @@ def compute_repo_data(repo_path: str) -> None:
         "almanack-version": _get_almanack_version(),
         "repo-unique-contributors": count_unique_contributors(repo=repo),
         "repo-unique-contributors-past-year": count_unique_contributors(
-            repo=repo, since=DATETIME_NOW - timedelta(days=365)
+            repo=repo, since=(one_year_ago := DATETIME_NOW - timedelta(days=365))
         ),
         "repo-unique-contributors-past-182-days": count_unique_contributors(
-            repo=repo, since=DATETIME_NOW - timedelta(days=182)
+            repo=repo, since=(half_year_ago := DATETIME_NOW - timedelta(days=182))
         ),
         "repo-tags-count": count_repo_tags(repo=repo),
+        "repo-tags-count-past-year": count_repo_tags(repo=repo, since=one_year_ago),
+        "repo-tags-count-past-182-days": count_repo_tags(
+            repo=repo, since=half_year_ago
+        ),
         "repo-agg-info-entropy": normalized_total_entropy,
         "repo-file-info-entropy": file_entropy,
     }

--- a/src/almanack/metrics/data.py
+++ b/src/almanack/metrics/data.py
@@ -308,6 +308,21 @@ def count_unique_contributors(
     return len(contributors)
 
 
+def count_repo_tags(repo: pygit2.Repository) -> int:
+    """
+    Counts the number of tags in a pygit2 repository.
+
+    Args:
+        repo (pygit2.Repository):
+            The repository to analyze.
+
+    Returns:
+        int:
+            The number of tags in the repository.
+    """
+    return sum(1 for ref in repo.references if ref.startswith("refs/tags/"))
+
+
 def compute_repo_data(repo_path: str) -> None:
     """
     Computes comprehensive data for a GitHub repository.
@@ -393,6 +408,7 @@ def compute_repo_data(repo_path: str) -> None:
         "repo-unique-contributors-past-182-days": count_unique_contributors(
             repo=repo, since=DATETIME_NOW - timedelta(days=182)
         ),
+        "repo-tags-count": count_repo_tags(repo=repo),
         "repo-agg-info-entropy": normalized_total_entropy,
         "repo-file-info-entropy": file_entropy,
     }

--- a/src/almanack/metrics/metrics.yml
+++ b/src/almanack/metrics/metrics.yml
@@ -113,6 +113,20 @@ metrics:
     result-type: "int"
     description: >-
       Count of the number of tags within the repository.
+  - name: "repo-tags-count-past-year"
+    id: "SGA-GL-0012"
+    result-type: "int"
+    description: >-
+      Count of the number of tags within the repository
+      within the last year from now (where now is a
+      reference to table value of almanack-table-datetime).
+  - name: "repo-tags-count-past-182-days"
+    id: "SGA-GL-0013"
+    result-type: "int"
+    description: >-
+      Count of the number of tags within the repository
+      within the last 182 days from now (where now is a
+      reference to table value of almanack-table-datetime).
   - name: "repo-agg-info-entropy"
     id: "SGA-VS-0001"
     result-type: "float"

--- a/src/almanack/metrics/metrics.yml
+++ b/src/almanack/metrics/metrics.yml
@@ -108,6 +108,11 @@ metrics:
       Count of unique contributors within the last 182 days
       from now (where now is a reference to table value
       of almanack-table-datetime).
+  - name: "repo-tags-count"
+    id: "SGA-GL-0011"
+    result-type: "int"
+    description: >-
+      Count of the number of tags within the repository.
   - name: "repo-agg-info-entropy"
     id: "SGA-VS-0001"
     result-type: "float"

--- a/tests/metrics/test_data.py
+++ b/tests/metrics/test_data.py
@@ -17,6 +17,7 @@ from almanack.metrics.data import (
     METRICS_TABLE,
     _get_almanack_version,
     compute_repo_data,
+    count_repo_tags,
     count_unique_contributors,
     default_branch_is_not_master,
     file_exists_in_repo,
@@ -602,3 +603,44 @@ def test_count_unique_contributors(tmp_path, files, since, expected_count):
 
     # Assert the result matches the expected count
     assert result == expected_count, f"Expected {expected_count}, got {result}"
+
+
+@pytest.mark.parametrize(
+    "files, expected_tag_count",
+    [
+        # No tags in the repository
+        (
+            [
+                {"files": {"file1.txt": "Initial content"}},
+                {"files": {"file2.txt": "Another content"}},
+            ],
+            0,
+        ),
+        # One tag in the repository
+        (
+            [
+                {"files": {"file1.txt": "Initial content"}, "tag": "v1.0"},
+                {"files": {"file2.txt": "Another content"}},
+            ],
+            1,
+        ),
+        # Multiple tags in the repository
+        (
+            [
+                {"files": {"file1.txt": "Initial content"}, "tag": "v1.0"},
+                {"files": {"file2.txt": "More content"}, "tag": "v1.1"},
+                {"files": {"file3.txt": "Even more content"}, "tag": "v2.0"},
+            ],
+            3,
+        ),
+    ],
+)
+def test_count_repo_tags(tmp_path, files, expected_tag_count):
+    """
+    Test count_repo_tags
+    """
+
+    repo = repo_setup(repo_path=tmp_path, files=files)
+
+    # Assert the tag count matches the expected value
+    assert count_repo_tags(repo) == expected_tag_count


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/main/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR adds a metric which counts the number of git tags associated with a repository. This is intended to begin work towards #160 , where we seek to understand whether the repository has version updates. This is a first step here where we begin to gather information about versioning under the assumption that software versions are somehow tied to git tags.

I thought about trying to dive deeper here with a semantic version check but this would only be a piece of the puzzle (this isn't the only versioning style). Wanted to get this simpler check in place before a more complex look emerges.

References #160

## What is the nature of your change?

- [ ] Content additions or updates (adds or updates content)
- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own contributions.
- [x] I have commented my content, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to related documentation (outside of book content).
- [x] My changes generate no new warnings.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests that prove my additions are effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
