### PR TITLE
Add GitHub workflow success ratio metrics for inferred build status

### DIFF
--- a/src/almanack/metrics/data.py
+++ b/src/almanack/metrics/data.py
@@ -694,12 +694,12 @@ def get_api_data(
                 and "X-RateLimit-Remaining" in response.headers
             ):
                 if attempt < retries - 1:
-                    print(
+                    LOGGER.warning(
                         f"Rate limit exceeded (attempt {attempt + 1}/{retries}). Retrying in {backoff} seconds..."
                     )
                     time.sleep(backoff)
                 else:
-                    print("Rate limit exceeded. All retry attempts exhausted.")
+                    LOGGER.warning("Rate limit exceeded. All retry attempts exhausted.")
                     return {}
             else:
                 # Raise other HTTP errors immediately

--- a/src/almanack/metrics/data.py
+++ b/src/almanack/metrics/data.py
@@ -667,8 +667,8 @@ def get_api_data(
     if params is None:
         params = {}
 
-    retries = 3  # Number of attempts for rate limit errors
-    backoff = 3  # Seconds to wait between retries
+    retries = 5  # Number of attempts for rate limit errors
+    backoff = 4  # Seconds to wait between retries
 
     for attempt in range(retries):
         try:

--- a/src/almanack/metrics/data.py
+++ b/src/almanack/metrics/data.py
@@ -700,14 +700,14 @@ def get_github_build_success_ratio(
     """
     # Validate and parse the repository URL
     parsed_url = urlparse(repo_url)
-    print(parsed_url)
     if parsed_url.netloc != "github.com" or not parsed_url.path:
-        return {"error": "Invalid GitHub repository URL"}
+        return {}
 
     try:
+        # gather the owner and repo name from the parsed url path
         owner, repo_name = parsed_url.path.strip("/").split("/")
     except ValueError:
-        return {"error": "Invalid GitHub repository URL structure"}
+        return {}
 
     # Fetch the latest workflow run data using get_api_data
     github_response = get_api_data(

--- a/src/almanack/metrics/data.py
+++ b/src/almanack/metrics/data.py
@@ -375,7 +375,7 @@ def compute_repo_data(repo_path: str) -> None:
     )
 
     # gather data from github repo workflows api
-    gh_workflows_data = get_github_build_success_ratio(
+    gh_workflows_data = get_github_build_metrics(
         repo_url=remote_url, branch=repo.head.shorthand, max_runs=100
     )
 
@@ -667,8 +667,8 @@ def get_api_data(
     if params is None:
         params = {}
 
-    retries = 5  # Number of attempts for rate limit errors
-    backoff = 10  # Seconds to wait between retries
+    retries = 10  # Number of attempts for rate limit errors
+    backoff = 15  # Seconds to wait between retries
 
     for attempt in range(retries):
         try:
@@ -711,7 +711,7 @@ def get_api_data(
     return {}  # Default return in case all retries fail
 
 
-def get_github_build_success_ratio(
+def get_github_build_metrics(
     repo_url: str,
     branch: str = "main",
     max_runs: int = 100,

--- a/src/almanack/metrics/data.py
+++ b/src/almanack/metrics/data.py
@@ -668,7 +668,7 @@ def get_api_data(
         params = {}
 
     retries = 5  # Number of attempts for rate limit errors
-    backoff = 4  # Seconds to wait between retries
+    backoff = 10  # Seconds to wait between retries
 
     for attempt in range(retries):
         try:

--- a/src/almanack/metrics/data.py
+++ b/src/almanack/metrics/data.py
@@ -667,7 +667,7 @@ def get_api_data(
     if params is None:
         params = {}
 
-    retries = 10  # Number of attempts for rate limit errors
+    retries = 30  # Number of attempts for rate limit errors
     backoff = 15  # Seconds to wait between retries
 
     for attempt in range(retries):

--- a/src/almanack/metrics/metrics.yml
+++ b/src/almanack/metrics/metrics.yml
@@ -196,7 +196,7 @@ metrics:
     description: >-
       Total number of workflow runs from GitHub
       (only applies to GitHub hosted repositories
-      which use workflows)
+      which use workflows).
   - name: "repo-agg-info-entropy"
     id: "SGA-VS-0001"
     result-type: "float"

--- a/src/almanack/metrics/metrics.yml
+++ b/src/almanack/metrics/metrics.yml
@@ -169,6 +169,33 @@ metrics:
     result-type: "int"
     description: >-
       Count of subscribers (or watchers) of the repository.
+  - name: "repo-gh-workflow-success-ratio"
+    id: "SGA-SF-0001"
+    result-type: "float"
+    description: >-
+      Ratio of succeeding workflow runs out of queried
+      workflow runs from GitHub (only applies to GitHub
+      hosted repositories which use workflows).
+  - name: "repo-gh-workflow-succeeding-runs"
+    id: "SGA-SF-0002"
+    result-type: "int"
+    description: >-
+      Number of succeeding workflow runs out of queried
+      workflow runs from GitHub (only applies to GitHub
+      hosted repositories which use workflows).
+  - name: "repo-gh-workflow-failing-runs"
+    id: "SGA-SF-0003"
+    result-type: "int"
+    description: >-
+      Number of failing workflow runs out of queried
+      workflow runs from GitHub (only applies to GitHub
+      hosted repositories which use workflows).
+  - name: "repo-gh-workflow-queried-total"
+    id: "SGA-SF-0004"
+    result-type: "int"
+    description: >-
+      Number of GitHub workflow runs queried for
+      GitHub workflow run metrics.
   - name: "repo-agg-info-entropy"
     id: "SGA-VS-0001"
     result-type: "float"

--- a/src/almanack/metrics/metrics.yml
+++ b/src/almanack/metrics/metrics.yml
@@ -194,8 +194,9 @@ metrics:
     id: "SGA-SF-0004"
     result-type: "int"
     description: >-
-      Number of GitHub workflow runs queried for
-      GitHub workflow run metrics.
+      Total number of workflow runs from GitHub
+      (only applies to GitHub hosted repositories
+      which use workflows)
   - name: "repo-agg-info-entropy"
     id: "SGA-VS-0001"
     result-type: "float"

--- a/tests/metrics/test_data.py
+++ b/tests/metrics/test_data.py
@@ -26,6 +26,7 @@ from almanack.metrics.data import (
     get_table,
     includes_common_docs,
     is_citable,
+    get_github_build_success_ratio,
 )
 from tests.data.almanack.repo_setup.create_repo import repo_setup
 
@@ -692,3 +693,22 @@ def test_get_api_data(current_repo):
     assert (
         repo_data["html_url"] == remote_url
     ), "The repo_data URL should match the repository's remote URL."
+
+
+def test_get_github_build_success_ratio():
+    """
+    Tests get_github_build_success_ratio
+    """
+
+    # perform a query against the upstream almanack repo
+    result = get_github_build_success_ratio(
+        repo_url="https://github.com/software-gardening/almanack",
+        branch="main",
+        max_runs=100,
+    )
+
+    # check the types for the results (actual values may vary)
+    assert isinstance(result["success_ratio"], float)
+    assert isinstance(result["total_runs"], int)
+    assert isinstance(result["successful_runs"], int)
+    assert isinstance(result["failing_runs"], int)

--- a/tests/metrics/test_data.py
+++ b/tests/metrics/test_data.py
@@ -23,7 +23,7 @@ from almanack.metrics.data import (
     default_branch_is_not_master,
     file_exists_in_repo,
     get_api_data,
-    get_github_build_success_ratio,
+    get_github_build_metrics,
     get_table,
     includes_common_docs,
     is_citable,
@@ -695,13 +695,13 @@ def test_get_api_data(current_repo):
     ), "The repo_data URL should match the repository's remote URL."
 
 
-def test_get_github_build_success_ratio():
+def test_get_github_build_metrics():
     """
-    Tests get_github_build_success_ratio
+    Tests get_github_build_metrics
     """
 
     # perform a query against the upstream almanack repo
-    result = get_github_build_success_ratio(
+    result = get_github_build_metrics(
         repo_url="https://github.com/software-gardening/almanack",
         branch="main",
         max_runs=100,

--- a/tests/metrics/test_data.py
+++ b/tests/metrics/test_data.py
@@ -21,12 +21,12 @@ from almanack.metrics.data import (
     count_repo_tags,
     count_unique_contributors,
     default_branch_is_not_master,
-    get_api_data,
     file_exists_in_repo,
+    get_api_data,
+    get_github_build_success_ratio,
     get_table,
     includes_common_docs,
     is_citable,
-    get_github_build_success_ratio,
 )
 from tests.data.almanack.repo_setup.create_repo import repo_setup
 

--- a/tests/metrics/test_data.py
+++ b/tests/metrics/test_data.py
@@ -21,7 +21,7 @@ from almanack.metrics.data import (
     count_repo_tags,
     count_unique_contributors,
     default_branch_is_not_master,
-    fetch_api_data,
+    get_api_data,
     file_exists_in_repo,
     get_table,
     includes_common_docs,
@@ -672,9 +672,9 @@ def test_count_repo_tags(tmp_path, files, since, expected_tag_count):
     assert count_repo_tags(repo, since=since) == expected_tag_count
 
 
-def test_fetch_api_data(current_repo):
+def test_get_api_data(current_repo):
     """
-    Test fetch_api_data using the current repository's remote URL.
+    Test get_api_data using the current repository's remote URL.
     """
     # Get the remote URL of the current repository
     remote_url = get_remote_url(current_repo)
@@ -683,7 +683,7 @@ def test_fetch_api_data(current_repo):
     ), "Remote URL could not be determined for the repository."
 
     # Fetch repository metadata
-    repo_data = fetch_api_data(remote_url)
+    repo_data = get_api_data(params={"url": remote_url})
 
     # Assertions to verify the response
     assert isinstance(repo_data, dict), "The returned repo_data should be a dictionary."


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/main/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR adds metrics which infer the current build status by using the latest workflow runs for the default head branch of a repository hosted on GitHub. I couldn't find an abstraction for this effort so we won't have these details yet for GitLab and similar, though I feel we should reach these eventually via a similar mechanism.

The thought process behind these metrics is: we can't possibly know how to build or safely perform a build for a repository without human understanding efforts, therefore we use a ratio of the repo-defined workflows to better understand what might be happening with builds (as software is commonly built to perform tests or other workflow-related work). This also I feel is related to testing coverage but we should give that particular aspect a deeper dive with other PR's.

Closes #161 
References #162

## What is the nature of your change?

- [ ] Content additions or updates (adds or updates content)
- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own contributions.
- [x] I have commented my content, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to related documentation (outside of book content).
- [x] My changes generate no new warnings.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests that prove my additions are effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
