### PR TITLE
Bump macos gh actions runner version

### DIFF
--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         # matrixed execution for parallel gh-action jobs
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-22.04, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR bumps the version of MacOS used by GH Actions runners as `macos-13` is no longer `macos-latest` (instead, latest is now `macos-14`). This also provides us the capability of testing with ARM-based architectures which could be important to understand when it comes to functionality.