### PR TITLE
Update dependabot to group Python updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,10 @@ updates:
     schedule:
       # Check for updates every week
       interval: "weekly"
+    groups:
+      python-packages:
+        patterns:
+          - "*"
 
   # Perform checks and updates for nodejs environment.
   - package-ecosystem: "npm"


### PR DESCRIPTION
This PR updates dependabot to group updates together so they may be applied in one PR when possible. Dependencies which don't align are normally updated individually.