### PR TITLE
Update GH Actions ubuntu version

### DIFF
--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         # matrixed execution for parallel gh-action jobs
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-22.04, macos-14]
+        os: [ubuntu-24.04, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
           poetry run pytest --ignore tests/test_build.py
   # tests the build of book content
   build_tests:
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
     steps:
       - uses: actions/checkout@v4
       - name: Install python env


### PR DESCRIPTION
This PR updates ubuntu-latest to 24.04 (latest) for use within GH Actions.