### PR TITLE
RF: configure skips for codespell in its config section not pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,14 +46,9 @@ repos:
     hooks:
       # Detects and corrects common typos in the codebase, improving
       # readability and reducing minor mistakes.
+      # Skip patterns are configured in [tool.codespell] in pyproject.toml
+      # so that `codespell` can be invoked directly with the same exclusions.
     -   id: codespell
-        exclude: |
-          (?x)^(
-              .*\.lock |
-              .*\.json |
-              .*\.bib |
-              .*\.ipynb
-          )$
         additional_dependencies:
         -   tomli
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,7 +111,7 @@ repos:
         additional_dependencies: ["bandit[toml]"]
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.13"
+    rev: "v0.15.14"
     hooks:
       # A fast linter that checks for stylistic errors in Python code,
       # helping maintain code quality and adherence to style guidelines.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,9 @@ ignore-words = "styles/config/vocabularies/almanack/accept.txt"
 # add capabilities for inline ignore for codespell linting
 # referenced from: https://github.com/codespell-project/codespell/issues/1212
 ignore-regex = ".{1024}|.*codespell-ignore.*"
+# Skip lockfiles, JSON, bibliography, notebooks (formerly excluded via
+# pre-commit's `exclude:` field) and PDFs so `codespell` can be run directly.
+skip = "*.lock,*.json,*.bib,*.ipynb,*.pdf"
 
 [tool.pytest.ini_options]
 testpaths = "tests"


### PR DESCRIPTION
this way could be just ran without pre-commit

this is minor one, feel free to drop/close.