### PR TITLE
Fix Zenodo DOI badge in README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,7 +116,7 @@ repos:
         additional_dependencies: ["bandit[toml]"]
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.13"
+    rev: "v0.15.14"
     hooks:
       # A fast linter that checks for stylistic errors in Python code,
       # helping maintain code quality and adherence to style guidelines.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![PyPI - Version](https://img.shields.io/pypi/v/almanack)
 [![Build Status](https://github.com/software-gardening/almanack/actions/workflows/pytest-tests.yml/badge.svg?branch=main)](https://github.com/software-gardening/almanack/actions/workflows/pytest-tests.yml?query=branch%3Amain)
 ![Coverage Status](https://raw.githubusercontent.com/software-gardening/almanack/main/media/coverage-badge.svg)
-[![Software DOI badge](https://zenodo.org/badge/DOI/10.5281/zenodo.14765835.svg)](https://doi.org/10.5281/zenodo.14765834)
+[![Software DOI badge](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.14765834-blue)](https://doi.org/10.5281/zenodo.14765834)
 
 The Software Gardening Almanack is an open-source handbook of applied guidance and tools for sustainable software development and maintenance.
 


### PR DESCRIPTION
It's a common issue for Zenodo badges that were copied/pasted from their site to not resolve and lead to the following README appearance over time

This PR fixes it by utilizing `shields.io` for a nearly identical appearance ([quick link](https://github.com/CodyCBakerPhD/almanack/tree/patch-1#the-software-gardening-almanack))

# Before

<img width="835" height="494" alt="image" src="https://github.com/user-attachments/assets/1be1eec3-bda9-498e-8c94-8b543e0765ea" />

# After

<img width="1099" height="562" alt="image" src="https://github.com/user-attachments/assets/0c18b75d-afd9-48fe-b74b-bb957c7ac2b0" />

